### PR TITLE
fix: dialog double scroll

### DIFF
--- a/src/client/components/menu/copy-code.tsx
+++ b/src/client/components/menu/copy-code.tsx
@@ -77,7 +77,7 @@ export const CopyCode = () => {
         </DrawerTrigger>
 
         <DrawerContent>
-          <RemoveScroll className="max-h-[80svh] overflow-auto p-4 scrollbar-thin">
+          <RemoveScroll className="flex max-h-[80svh] flex-col p-4">
             <DrawerHeader>
               <DrawerTitle>{title}</DrawerTitle>
               <DrawerDescription>{description}</DrawerDescription>
@@ -102,7 +102,7 @@ export const CopyCode = () => {
         </DialogTrigger>
         <TooltipContent>Copy current theme as code</TooltipContent>
       </Tooltip>
-      <DialogContent className="w-full max-w-screen-lg">
+      <DialogContent className="flex max-h-[95vh] w-[98vw] max-w-screen-lg flex-col">
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>{description}</DialogDescription>
@@ -121,7 +121,7 @@ const Content = () => {
   const themeTemplate = configToCss(config);
 
   return (
-    <div className="relative grid h-full max-h-[768px] w-full overflow-auto rounded-md border bg-muted">
+    <div className="relative grid min-h-0 rounded-md border bg-muted">
       <Button
         className="absolute right-2 top-2"
         size="sm"
@@ -141,7 +141,7 @@ const Content = () => {
         )}
         Copy
       </Button>
-      <pre>
+      <pre className="h-full overflow-auto">
         <code className="block rounded px-2 py-3 font-mono text-xs lg:text-sm">
           {themeTemplate}
         </code>


### PR DESCRIPTION
## Problems
### Double scrollbar on mobile
<img width="300" alt="image" src="https://github.com/jln13x/ui.jln.dev/assets/11497316/2cf35142-efbe-46ef-ad3b-03cf152f52a8">

### Dialog overflow on smaller screen
<img width="500" alt="image" src="https://github.com/jln13x/ui.jln.dev/assets/11497316/e06e357f-d038-4088-b494-6e534ac0543f">

## Fixes
- Dialog's max height
- Only code area is scrollable

## Additionals
- Dialog's width to 98% to give "padding" illusion (together with max height)
- Copy button stays in place

https://github.com/jln13x/ui.jln.dev/assets/11497316/9cffea14-bc7d-4840-b27e-143f8c94b284
